### PR TITLE
Support multi byte characters as default on Term::Readline::Caroline

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -6,14 +6,13 @@ requires 'Class::Accessor::Lite', 0.05;
 requires 'Term::ReadKey', 2.30;
 requires 'IO::Handle';
 requires 'Unicode::EastAsianWidth::Detect', '0.03';
+requires 'Term::Encoding';
 recommends 'Term::ReadLine';
 
 if ($^O eq 'MSWin32') {
     requires 'Win32::API';
     requires 'Encode';
-    requires 'Term::Encoding';
     requires 'Win32::Console::ANSI';
-    requires 'Term::Encoding';
 }
 
 on 'test' => sub {

--- a/lib/Term/ReadLine/Caroline.pm
+++ b/lib/Term/ReadLine/Caroline.pm
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use utf8;
 use 5.008_001;
+use Term::Encoding qw/term_encoding/;
 
 our @ISA = qw(Term::ReadLine::Stub);
 
@@ -12,6 +13,12 @@ sub ReadLine { __PACKAGE__ }
 
 sub new {
     my $class = shift;
+
+    # Support multi byte characters
+    my $encoding = term_encoding();
+    binmode *STDIN,  ":encoding(${encoding})";
+    binmode *STDOUT, ":encoding(${encoding})";
+
     my $self = bless {
         caroline => Caroline->new(),
         IN => *STDIN,


### PR DESCRIPTION
Please review this.
